### PR TITLE
Add Azure mailNickname claim

### DIFF
--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -87,7 +87,36 @@ class AuthenticationController extends \Icinga\Controllers\AuthenticationControl
                 $authSuccess=true;
                 $_SESSION['id_token'] = $oidc->getIdToken();
                 $claims = $oidc->requestUserInfo();
-                $username = $claims->name;
+
+                // ---- Begin mailNickname Extraction ----
+                Logger::info('OICD Claims: ' . print_r($claims, true));
+                $username = null;
+                if (isset($claims->mailNickname)) {
+                    $username = $claims->mailNickname;
+                    Logger::info('mailNickname found in userinfo: ' . $username);
+                } else {
+                    // Try to extract from id_token if not in userinfo
+                    $idToken = $oidc->getIdToken();
+                    if ($idToken) {
+                        $parts = explode('.', $idToken);
+                        if (count($parts) === 3) {
+                            $payload = base64_decode(strtr($parts[1], '-_', '+/'));
+                            $decoded = json_decode($payload, true);
+                            Logger::info('Decoded id_token: ' . print_r($decoded, true));
+                            if (isset($decoded['mailNickname'])) {
+                                $username = $decoded['mailNickname'];
+                                Logger::info('mailNickname found in id_token: ' . $username);
+                            }
+                        }
+                    }
+                    // Fallbacks
+                    if (empty($username)) {
+                        $username = $claims->name ?? $claims->displayName ?? '';
+                        Logger::info('mailNickname not found, fallback username: ' . $username);
+                    }
+                }
+                // ---- End mailNickname Extraction ----
+
                 $usernameBlacklist = StringHelper::trimSplit($provider->usernameblacklist);
                 foreach ($usernameBlacklist as $notAllowedName){
                     if(fnmatch($notAllowedName,$username)){


### PR DESCRIPTION
 Use 'mailNickname' as username from OIDC claims

- Replaced `$username = $claims->name` logic.
- Now uses `$claims->mailNickname` if available.
- If not present, attempts to decode `mailNickname` from the ID token payload.
- Falls back to 'name' or 'displayName' if 'mailNickname' cannot be found.